### PR TITLE
chore(renovate): migrate to renovate-presets default.json5

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>giantswarm/renovate-presets:default.json5",
+    "github>giantswarm/renovate-presets:lang-go.json5"
+  ]
+}


### PR DESCRIPTION
Replaces `config:recommended` with `github>giantswarm/renovate-presets:default.json5`.

Adds `github>giantswarm/renovate-presets:lang-go.json5` (Go repo).

The old `renovate.json` is replaced by `renovate.json5`. No other repo-specific configuration was present.