### PR TITLE
feat(ci): release darwin and windows binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@8.2.2
+  architect: giantswarm/architect@9.1.0
 
 workflows:
   go-build:
@@ -9,7 +9,20 @@ workflows:
           context: architect
           name: go-build-luigi
           binary: luigi
+          architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
           # Needed to trigger job also on git tag.
           filters:
             tags:
               only: /^v.*/
+
+      - architect/upload-release-assets:
+          context: architect
+          name: upload-release-assets
+          binary: luigi
+          requires:
+            - go-build-luigi
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `luigi-windows-<arch>.exe`.
 - Updated golang.org/x/sys so the project can be built on mac and with go 1.18. See: https://github.com/golang/go/issues/49219
 - Upgrade dependencies
 - Upgrade to Go 1.21


### PR DESCRIPTION
## What

- `go-build`: adds `darwin/amd64`, `darwin/arm64`, `windows/amd64`, `windows/arm64` to the `architectures` list.
- `upload-release-assets`: new job; uploads binaries and cosign `.bundle` files to the GitHub Release on tags.
- Bumps architect orb 8.2.2 to 9.1.0, which names Windows binaries `<binary>-windows-<arch>.exe`.

Same pattern as giantswarm/muster#796.